### PR TITLE
Feature/ai connect 3

### DIFF
--- a/src/main/java/com/example/news/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/news/config/RestTemplateConfig.java
@@ -2,6 +2,7 @@ package com.example.news.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -9,6 +10,10 @@ public class RestTemplateConfig {
 
   @Bean
   public RestTemplate restTemplate() {
-    return new RestTemplate();
+    SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
+    factory.setConnectTimeout(10000); // 10초 연결 타임아웃
+    factory.setReadTimeout(30000);    // 30초 읽기 타임아웃
+    
+    return new RestTemplate(factory);
   }
 }

--- a/src/main/java/com/example/news/dto/ai/AISummaryRequest.java
+++ b/src/main/java/com/example/news/dto/ai/AISummaryRequest.java
@@ -1,12 +1,24 @@
 package com.example.news.dto.ai;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Builder;
 import lombok.Getter;
 
 @Getter
 @Builder
 public class AISummaryRequest {
-  private String text;
-  private String language;
-  private int maxLength;
+  @JsonProperty("inputs")
+  private String inputs;
+
+  public AISummaryRequest(String inputs) {
+    this.inputs = inputs;
+  }
+
+  public String getInputs() {
+    return inputs;
+  }
+
+  public void setInputs(String inputs) {
+    this.inputs = inputs;
+  }
 }

--- a/src/main/java/com/example/news/dto/ai/AISummaryResponse.java
+++ b/src/main/java/com/example/news/dto/ai/AISummaryResponse.java
@@ -1,15 +1,20 @@
 package com.example.news.dto.ai;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter
 @Setter
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class AISummaryResponse {
-  private String summary;
-  private String originalText;
-  private int originalLength;
-  private int summaryLength;
-  private double compressionRatio;
+  private String summary_text;
 
+  public String getSummary_text() {
+    return summary_text;
+  }
+
+  public void setSummary_text(String summary_text) {
+    this.summary_text = summary_text;
+  }
 }

--- a/src/main/java/com/example/news/entity/User.java
+++ b/src/main/java/com/example/news/entity/User.java
@@ -4,6 +4,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -17,6 +18,7 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
+@Table(name = "users")
 public class User {
   @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;

--- a/src/main/java/com/example/news/service/impl/AIServiceImpl.java
+++ b/src/main/java/com/example/news/service/impl/AIServiceImpl.java
@@ -82,15 +82,15 @@ public class AIServiceImpl implements AIService {
     try {
       String originalText = request.getOriginalText().trim();
 
-      // ✅ 길이 제한 (200자 이하)
-      if (originalText.length() > 200) {
-        originalText = originalText.substring(0, 200);
+      // ✅ 길이 제한 (1000자 이하)
+      if (originalText.length() > 1000) {
+        originalText = originalText.substring(0, 1000);
       }
 
       // ✅ 본문 구성
       Map<String, Object> requestBody = new HashMap<>();
       requestBody.put("inputs", originalText);
-      
+
       String json = objectMapper.writeValueAsString(requestBody);
       log.info("Request body: {}", json);
 

--- a/src/main/java/com/example/news/service/impl/AIServiceImpl.java
+++ b/src/main/java/com/example/news/service/impl/AIServiceImpl.java
@@ -80,6 +80,10 @@ public class AIServiceImpl implements AIService {
   @Override
   public SummaryResponse summarizeText(SummaryRequest request) {
     try {
+      // ✅ 토큰 상태 확인
+      log.info("API Token length: {}", apiToken != null ? apiToken.length() : 0);
+      log.info("API Token starts with: {}", apiToken != null ? apiToken.substring(0, Math.min(10, apiToken.length())) : "null");
+      
       String originalText = request.getOriginalText().trim();
 
       // ✅ 길이 제한 (1000자 이하)
@@ -102,7 +106,9 @@ public class AIServiceImpl implements AIService {
 
       HttpEntity<String> entity = new HttpEntity<>(json, headers);
 
-      // ✅ 요청
+      // ✅ 요약 요청
+      log.info("Calling HuggingFace API with token: {}", apiToken != null ? apiToken.substring(0, 10) + "..." : "null");
+
       ResponseEntity<String> response = restTemplate.postForEntity(
           "https://api-inference.huggingface.co/models/facebook/bart-large-cnn",
           entity,
@@ -115,11 +121,17 @@ public class AIServiceImpl implements AIService {
       JsonNode root = objectMapper.readTree(response.getBody());
 
       if (root.isArray() && root.size() > 0 && root.get(0).has("summary_text")) {
-        String summary = root.get(0).get("summary_text").asText();
+        String englishSummary = root.get(0).get("summary_text").asText();
+
+        // ✅ 영어 요약을 한글로 번역
+        String koreanSummary = translateToKorean(englishSummary);
+
+        log.info("English summary: {}", englishSummary);
+        log.info("Korean summary: {}", koreanSummary);
 
         return SummaryResponse.builder()
             .originalText(request.getOriginalText())
-            .summaryText(summary)
+            .summaryText(koreanSummary)
             .createdAt(LocalDateTime.now())
             .build();
       } else {
@@ -128,6 +140,93 @@ public class AIServiceImpl implements AIService {
 
     } catch (Exception e) {
       throw new AIServiceException("AI 요약 요청 중 오류 발생", e);
+    }
+  }
+
+  /**
+   * LibreTranslate API를 사용하여 영어를 한글로 번역
+   */
+  private String translateToKorean(String englishText) {
+    try {
+      // LibreTranslate API 요청 본문
+      Map<String, String> translateRequest = new HashMap<>();
+      translateRequest.put("q", englishText);
+      translateRequest.put("source", "en");
+      translateRequest.put("target", "ko");
+
+      String translateJson = objectMapper.writeValueAsString(translateRequest);
+      log.info("Translation request: {}", translateJson);
+
+      // 번역 API 헤더
+      HttpHeaders translateHeaders = new HttpHeaders();
+      translateHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+      HttpEntity<String> translateEntity = new HttpEntity<>(translateJson, translateHeaders);
+
+      // LibreTranslate API 호출
+      ResponseEntity<String> translateResponse = restTemplate.postForEntity(
+          "https://libretranslate.de/translate",
+          translateEntity,
+          String.class
+      );
+
+      log.info("Translation response status: {}", translateResponse.getStatusCode());
+      log.info("Translation response body: {}", translateResponse.getBody());
+
+      // 번역 결과 파싱
+      JsonNode translateRoot = objectMapper.readTree(translateResponse.getBody());
+      if (translateRoot.has("translatedText")) {
+        return translateRoot.get("translatedText").asText();
+      } else {
+        log.warn("번역 응답에 translatedText가 없습니다. 원본 영어 텍스트를 반환합니다.");
+        return englishText;
+      }
+
+    } catch (Exception e) {
+      log.error("LibreTranslate 번역 중 오류 발생: {}", e.getMessage());
+      
+      // LibreTranslate 실패 시 MyMemory Translation API 시도
+      try {
+        log.info("MyMemory Translation API로 재시도...");
+        return translateWithMyMemory(englishText);
+      } catch (Exception e2) {
+        log.error("MyMemory 번역도 실패: {}", e2.getMessage());
+        // 번역 실패 시 원본 영어 텍스트 반환
+        return englishText;
+      }
+    }
+  }
+
+  /**
+   * MyMemory Translation API를 사용하여 영어를 한글로 번역 (백업용)
+   */
+  private String translateWithMyMemory(String englishText) {
+    try {
+      // MyMemory API는 GET 요청 사용
+      String encodedText = java.net.URLEncoder.encode(englishText, java.nio.charset.StandardCharsets.UTF_8);
+      String url = String.format("https://api.mymemory.translated.net/get?q=%s&langpair=en|ko", encodedText);
+      
+      log.info("MyMemory Translation URL: {}", url);
+      
+      ResponseEntity<String> response = restTemplate.getForEntity(url, String.class);
+      
+      log.info("MyMemory response status: {}", response.getStatusCode());
+      log.info("MyMemory response body: {}", response.getBody());
+      
+      JsonNode root = objectMapper.readTree(response.getBody());
+      if (root.has("responseData") && root.get("responseData").has("translatedText")) {
+        return root.get("responseData").get("translatedText").asText();
+      } else {
+        log.warn("MyMemory 번역 응답에 translatedText가 없습니다.");
+        return englishText;
+      }
+      
+    } catch (com.fasterxml.jackson.core.JsonProcessingException e) {
+      log.error("MyMemory 번역 중 JSON 파싱 오류 발생: {}", e.getMessage());
+      return englishText;
+    } catch (Exception e) {
+      log.error("MyMemory 번역 중 기타 오류 발생: {}", e.getMessage());
+      return englishText;
     }
   }
 

--- a/src/main/java/com/example/news/service/impl/AIServiceImpl.java
+++ b/src/main/java/com/example/news/service/impl/AIServiceImpl.java
@@ -8,20 +8,30 @@ import com.example.news.dto.ai.AISummaryRequest;
 import com.example.news.dto.ai.AISummaryResponse;
 import com.example.news.exception.AIServiceException;
 import com.example.news.service.AIService;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDateTime;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 @RequiredArgsConstructor
 public class AIServiceImpl implements AIService {
 
   private final RestTemplate restTemplate;
+  private final ObjectMapper objectMapper = new ObjectMapper();
+  private static final Logger log = LoggerFactory.getLogger(AIServiceImpl.class);
 
   @Value("${ai.service.url}")
   private String aiServiceUrl;
@@ -29,76 +39,137 @@ public class AIServiceImpl implements AIService {
   @Value("${ai.service.api-key}")
   private String apiKey;
 
+  @Value("${huggingface.api.token}")
+  private String apiToken;
+
+
+
+//  @Override
+//  public SummaryResponse summarizeText(SummaryRequest request) {
+//    try{
+//      //실제 AI 서비스 연동 구현 필요
+//      AISummaryRequest aiRequest = AISummaryRequest.builder()
+//          .text(request.getOriginalText())
+//          .language("ko")
+//          .maxLength(200)
+//          .build();
+//
+//      HttpHeaders headers = createHeaders();
+//      HttpEntity<AISummaryRequest> entity = new HttpEntity<>(aiRequest, headers);
+//
+//      AISummaryResponse response = restTemplate.postForObject(
+//          aiServiceUrl + "/api/v1/summarize",
+//          entity,
+//          AISummaryResponse.class
+//      );
+//
+//      if (response == null || response.getSummary() == null) {
+//        throw new AIServiceException("Failed to get summary from AI service");
+//      }
+//      return SummaryResponse.builder()
+//          .originalText(request.getOriginalText())
+//          .summaryText(response.getSummary())
+//          .createdAt(LocalDateTime.now())
+//          .build();
+//    } catch (Exception e) {
+//      throw new AIServiceException("Failed to summarize text.", e);
+//    }
+//  }
+
+
   @Override
   public SummaryResponse summarizeText(SummaryRequest request) {
-    try{
-      //실제 AI 서비스 연동 구현 필요
-      AISummaryRequest aiRequest = AISummaryRequest.builder()
-          .text(request.getOriginalText())
-          .language("ko")
-          .maxLength(200)
-          .build();
+    try {
+      String originalText = request.getOriginalText().trim();
 
-      HttpHeaders headers = createHeaders();
-      HttpEntity<AISummaryRequest> entity = new HttpEntity<>(aiRequest, headers);
+      // ✅ 길이 제한 (200자 이하)
+      if (originalText.length() > 200) {
+        originalText = originalText.substring(0, 200);
+      }
 
-      AISummaryResponse response = restTemplate.postForObject(
-          aiServiceUrl + "/api/v1/summarize",
+      // ✅ 본문 구성
+      Map<String, Object> requestBody = new HashMap<>();
+      requestBody.put("inputs", originalText);
+      
+      String json = objectMapper.writeValueAsString(requestBody);
+      log.info("Request body: {}", json);
+
+      // ✅ 헤더 설정
+      HttpHeaders headers = new HttpHeaders();
+      headers.setBearerAuth(apiToken);
+      headers.setContentType(MediaType.APPLICATION_JSON);
+      headers.setAccept(Collections.singletonList(MediaType.APPLICATION_JSON));
+
+      HttpEntity<String> entity = new HttpEntity<>(json, headers);
+
+      // ✅ 요청
+      ResponseEntity<String> response = restTemplate.postForEntity(
+          "https://api-inference.huggingface.co/models/facebook/bart-large-cnn",
           entity,
-          AISummaryResponse.class
+          String.class
       );
 
-      if (response == null || response.getSummary() == null) {
-        throw new AIServiceException("Failed to get summary from AI service");
+      log.info("Response status: {}", response.getStatusCode());
+      log.info("Response body: {}", response.getBody());
+
+      JsonNode root = objectMapper.readTree(response.getBody());
+
+      if (root.isArray() && root.size() > 0 && root.get(0).has("summary_text")) {
+        String summary = root.get(0).get("summary_text").asText();
+
+        return SummaryResponse.builder()
+            .originalText(request.getOriginalText())
+            .summaryText(summary)
+            .createdAt(LocalDateTime.now())
+            .build();
+      } else {
+        throw new AIServiceException("AI 응답에 summary_text가 없습니다.");
       }
-      return SummaryResponse.builder()
-          .originalText(request.getOriginalText())
-          .summaryText(response.getSummary())
-          .createdAt(LocalDateTime.now())
-          .build();
+
     } catch (Exception e) {
-      throw new AIServiceException("Failed to summarize text.", e);
+      throw new AIServiceException("AI 요약 요청 중 오류 발생", e);
     }
   }
+
+
 
   @Override
-  public SummaryResponse searchText(SummaryRequest request){
-    try {
-      // 실제 AI 서비스 연동 구현 필요
-      AISearchRequest aiRequest = AISearchRequest.builder()
-          .query(request.getOriginalText())
-          .language("ko")
-          .maxResults(1)
-          .build();
-
-      HttpHeaders headers = createHeaders();
-      HttpEntity<AISearchRequest> entity = new HttpEntity<>(aiRequest, headers);
-
-      AISearchResponse response = restTemplate.postForObject(
-          aiServiceUrl + "/api/v1/search",
-          entity,
-          AISearchResponse.class
-      );
-
-      if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
-        throw new AIServiceException("No search results found");
-      }
-
-      return SummaryResponse.builder()
-          .originalText(request.getOriginalText())
-          .summaryText(response.getResults().get(0).getSummary())
-          .createdAt(LocalDateTime.now())
-          .build();
-    } catch (Exception e) {
-      throw new AIServiceException("Failed to search text.", e);
-    }
+  public SummaryResponse searchText(SummaryRequest request) {
+    throw new UnsupportedOperationException("이 기능은 아직 구현되지 않았습니다.");
   }
-
-  private HttpHeaders createHeaders() {
-    HttpHeaders headers = new HttpHeaders();
-    headers.setContentType(MediaType.APPLICATION_JSON);
-    headers.set("X-API-Key", apiKey);
-    return headers;
-  }
-
 }
+
+
+//  @Override
+//  public SummaryResponse searchText(SummaryRequest request){
+//    try {
+//      // 실제 AI 서비스 연동 구현 필요
+//      AISearchRequest aiRequest = AISearchRequest.builder()
+//          .query(request.getOriginalText())
+//          .language("ko")
+//          .maxResults(1)
+//          .build();
+//
+//      HttpHeaders headers = createHeaders();
+//      HttpEntity<AISearchRequest> entity = new HttpEntity<>(aiRequest, headers);
+//
+//      AISearchResponse response = restTemplate.postForObject(
+//          aiServiceUrl + "/api/v1/search",
+//          entity,
+//          AISearchResponse.class
+//      );
+//
+//      if (response == null || response.getResults() == null || response.getResults().isEmpty()) {
+//        throw new AIServiceException("No search results found");
+//      }
+//
+//      return SummaryResponse.builder()
+//          .originalText(request.getOriginalText())
+//          .summaryText(response.getResults().get(0).getSummary())
+//          .createdAt(LocalDateTime.now())
+//          .build();
+//    } catch (Exception e) {
+//      throw new AIServiceException("Failed to search text.", e);
+//    }
+//  }
+


### PR DESCRIPTION
**[ TODO ]**
- 영어 전문 요약 API 모델 연동
- 번역 API 모델 연동
- Postman API 테스트 200ok 코드 반환 확인


📌 AIServiceImpl 클래스

- 영어 본문 요약 API 모델 연동
- 번역 API 모델 연동


**[ 수정내용 ]**

- 한글을 지원하는  본문 요약 API 모델을 찾지 못해 영어 본문 번역  API 모델로 방향을 전환하여 연동
- 추가적으로 영어 번역 API 모델을 연동


**[ 주요 변경사항 ]**

요약 API 모델 변경 :
"nlp04/korean_text_summarization_news_v3", "nlp04/korean_text_summarization_news_v4", 
"nlp04/korean_text_summarization_news_v5", "digit82/kobart-summarization", "gogamza/kobart-base-v2",
"ainize/kobart-news",.... 
 → https://api-inference.huggingface.co/models/facebook/bart-large-cnn ( 최종 연동 모델 )

**[ 변경 이유 ]**

대부분의 한글 요약 API 모델은 Python 언어를 지원하기 때문에 JAVA 연동하기 어려움

**[ NEXT ]**

Elastic Search 연동 