### PR TITLE
Elastic Search 연동 작업 (3차)

### DIFF
--- a/src/main/java/com/example/news/config/CustomLogoutSuccessHandler.java
+++ b/src/main/java/com/example/news/config/CustomLogoutSuccessHandler.java
@@ -1,0 +1,28 @@
+package com.example.news.config;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@Slf4j
+public class CustomLogoutSuccessHandler implements LogoutSuccessHandler {
+    
+    @Override
+    public void onLogoutSuccess(HttpServletRequest request, 
+                               HttpServletResponse response, 
+                               Authentication authentication) throws IOException, ServletException {
+        
+        log.info("로그아웃 성공 핸들러 호출");
+        
+        // JSON 응답으로 로그아웃 성공 메시지 반환
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().write("{\"message\":\"로그아웃이 성공적으로 완료되었습니다.\",\"status\":\"success\"}");
+    }
+} 

--- a/src/main/java/com/example/news/config/CustomOAuth2UserService.java
+++ b/src/main/java/com/example/news/config/CustomOAuth2UserService.java
@@ -1,0 +1,26 @@
+package com.example.news.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class CustomOAuth2UserService extends DefaultOAuth2UserService {
+    
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User user = super.loadUser(userRequest);
+        
+        log.info("OAuth2 사용자 정보 로드: provider={}, attributes={}", 
+                userRequest.getClientRegistration().getRegistrationId(), 
+                user.getAttributes());
+        
+        return user;
+    }
+} 

--- a/src/main/java/com/example/news/config/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/news/config/OAuth2SuccessHandler.java
@@ -60,6 +60,9 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         if (requestURI.contains("/login/oauth2/code/google")) {
             return "google";
         }
+        if (requestURI.contains("/login/oauth2/code/kakao")) {
+            return "kakao";
+        }
         
         // OAuth2 인증 요청 URL에서 제공자 감지 (fallback)
         if (requestURI.contains("/oauth2/authorization/naver")) {
@@ -68,8 +71,10 @@ public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler 
         if (requestURI.contains("/oauth2/authorization/google")) {
             return "google";
         }
+        if (requestURI.contains("/oauth2/authorization/kakao")) {
+            return "kakao";
+        }
         
-        // 추후 카카오 추가 시 확장
         log.warn("알 수 없는 OAuth2 제공자: {}", requestURI);
         return "unknown";
     }

--- a/src/main/java/com/example/news/config/OAuth2SuccessHandler.java
+++ b/src/main/java/com/example/news/config/OAuth2SuccessHandler.java
@@ -1,0 +1,83 @@
+package com.example.news.config;
+
+import com.example.news.dto.OAuth2UserInfo;
+import com.example.news.entity.User;
+import com.example.news.service.OAuth2ProviderService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OAuth2SuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
+    
+    private final List<OAuth2ProviderService> oAuth2ProviderServices;
+    private final ObjectMapper objectMapper;
+    
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, 
+                                      HttpServletResponse response, 
+                                      Authentication authentication) throws IOException, ServletException {
+        
+        OAuth2User oAuth2User = (OAuth2User) authentication.getPrincipal();
+        String provider = getProviderFromRequest(request);
+        
+        log.info("OAuth2 로그인 성공: provider={}", provider);
+        
+        OAuth2ProviderService providerService = findProviderService(provider);
+        OAuth2UserInfo userInfo = providerService.convertToUserInfo(oAuth2User);
+        User user = providerService.processOAuth2Login(userInfo);
+        
+        // JSESSIONID를 URL에 포함하여 리다이렉트
+        String sessionId = request.getSession().getId();
+        String redirectUrl = "/api/v1/auth/login-success?sessionId=" + sessionId;
+        
+        log.info("로그인 성공 후 리다이렉트: {}", redirectUrl);
+        
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+    
+    private String getProviderFromRequest(HttpServletRequest request) {
+        String requestURI = request.getRequestURI();
+        log.info("요청 URI: {}", requestURI);
+        
+        // OAuth2 콜백 URL에서 제공자 감지
+        if (requestURI.contains("/login/oauth2/code/naver")) {
+            return "naver";
+        }
+        if (requestURI.contains("/login/oauth2/code/google")) {
+            return "google";
+        }
+        
+        // OAuth2 인증 요청 URL에서 제공자 감지 (fallback)
+        if (requestURI.contains("/oauth2/authorization/naver")) {
+            return "naver";
+        }
+        if (requestURI.contains("/oauth2/authorization/google")) {
+            return "google";
+        }
+        
+        // 추후 카카오 추가 시 확장
+        log.warn("알 수 없는 OAuth2 제공자: {}", requestURI);
+        return "unknown";
+    }
+    
+    private OAuth2ProviderService findProviderService(String provider) {
+        return oAuth2ProviderServices.stream()
+                .filter(service -> service.getProviderName().equals(provider))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("지원하지 않는 OAuth2 제공자입니다: " + provider));
+    }
+} 

--- a/src/main/java/com/example/news/config/RestTemplateConfig.java
+++ b/src/main/java/com/example/news/config/RestTemplateConfig.java
@@ -4,6 +4,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
+import java.net.http.HttpClient;
+import java.time.Duration;
 
 @Configuration
 public class RestTemplateConfig {
@@ -11,8 +13,8 @@ public class RestTemplateConfig {
   @Bean
   public RestTemplate restTemplate() {
     SimpleClientHttpRequestFactory factory = new SimpleClientHttpRequestFactory();
-    factory.setConnectTimeout(10000); // 10초 연결 타임아웃
-    factory.setReadTimeout(120000);   // 120초 읽기 타임아웃 (HuggingFace API 모델 로딩 시간 고려)
+    factory.setConnectTimeout(30000); // 30초 연결 타임아웃
+    factory.setReadTimeout(300000);   // 5분 읽기 타임아웃 (HuggingFace API 모델 로딩 시간 고려)
     
     return new RestTemplate(factory);
   }

--- a/src/main/java/com/example/news/config/SecurityConfig.java
+++ b/src/main/java/com/example/news/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.example.news.config;
 
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -9,7 +10,11 @@ import org.springframework.security.web.SecurityFilterChain;
 
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final CustomLogoutSuccessHandler logoutSuccessHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -21,7 +26,9 @@ public class SecurityConfig {
                     "/api/v1/summaries", // 요약,번역 API 접근 허용
                     "/api/v1/summaries/**",
                     "/api/v1/elasticsearch/**", // Elasticsearch API 접근 허용
-                    "/api/v1/integrated-news/**" // 통합 뉴스 API 접근 허용
+                    "/api/v1/integrated-news/**", // 통합 뉴스 API 접근 허용
+                    "/api/v1/auth/**", // 인증 관련 엔드포인트
+                    "/oauth2/**" // OAuth2 관련 엔드포인트
                 ).permitAll()
                 // 회원 전용 엔드포인트
                 .requestMatchers(
@@ -30,8 +37,26 @@ public class SecurityConfig {
                 ).authenticated()
                 // 나머지 모든 요청은 인증 필요
                 .anyRequest().authenticated()
+            )
+            .oauth2Login(oauth2 -> oauth2
+                .successHandler(oAuth2SuccessHandler)
+                .userInfoEndpoint(userInfo -> userInfo
+                    .userService(customOAuth2UserService())
+                )
+            )
+            .logout(logout -> logout
+                .logoutUrl("/api/v1/auth/logout")
+                .invalidateHttpSession(true)
+                .clearAuthentication(true)
+                .deleteCookies("JSESSIONID")
+                .logoutSuccessHandler(logoutSuccessHandler)
             );
         
         return http.build();
+    }
+    
+    @Bean
+    public CustomOAuth2UserService customOAuth2UserService() {
+        return new CustomOAuth2UserService();
     }
 } 

--- a/src/main/java/com/example/news/config/WebConfig.java
+++ b/src/main/java/com/example/news/config/WebConfig.java
@@ -1,5 +1,8 @@
 package com.example.news.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
@@ -7,13 +10,20 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class WebConfig implements WebMvcConfigurer {
 
-    @Override
-    public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/**")
-                .allowedOriginPatterns("*")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
-                .allowedHeaders("*")
-                .allowCredentials(true)
-                .maxAge(3600);
-    }
+  @Override
+  public void addCorsMappings(CorsRegistry registry) {
+    registry.addMapping("/**")
+        .allowedOriginPatterns("*")
+        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+        .allowedHeaders("*")
+        .allowCredentials(true)
+        .maxAge(3600);
+  }
+  
+  @Bean
+  public ObjectMapper objectMapper() {
+    ObjectMapper mapper = new ObjectMapper();
+    mapper.registerModule(new JavaTimeModule());
+    return mapper;
+  }
 } 

--- a/src/main/java/com/example/news/controller/AuthController.java
+++ b/src/main/java/com/example/news/controller/AuthController.java
@@ -1,0 +1,126 @@
+package com.example.news.controller;
+
+import com.example.news.entity.User;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.web.bind.annotation.*;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.util.HashMap;
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+@Slf4j
+public class AuthController {
+    
+    @GetMapping("/login-success")
+    public ResponseEntity<Map<String, Object>> loginSuccess(
+            @AuthenticationPrincipal OAuth2User oAuth2User,
+            @RequestParam(required = false) String sessionId,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+        
+        log.info("로그인 성공 엔드포인트 호출, sessionId: {}", sessionId);
+        
+        // sessionId가 제공된 경우 쿠키로 설정
+        if (sessionId != null && !sessionId.isEmpty()) {
+            Cookie sessionCookie = new Cookie("JSESSIONID", sessionId);
+            sessionCookie.setPath("/");
+            sessionCookie.setHttpOnly(true);
+            sessionCookie.setSecure(false); // 개발환경에서는 false, 프로덕션에서는 true
+            response.addCookie(sessionCookie);
+            log.info("JSESSIONID 쿠키 설정: {}", sessionId);
+        }
+        
+        Map<String, Object> responseData = new HashMap<>();
+        responseData.put("message", "로그인이 성공했습니다.");
+        responseData.put("user", oAuth2User.getAttributes());
+        responseData.put("sessionId", sessionId);
+        
+        return ResponseEntity.ok(responseData);
+    }
+    
+    @GetMapping("/test")
+    public ResponseEntity<Map<String, String>> test() {
+        log.info("인증 테스트 엔드포인트 호출");
+        
+        Map<String, String> response = new HashMap<>();
+        response.put("message", "인증 테스트 성공");
+        response.put("status", "OK");
+        
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/test-with-session")
+    public ResponseEntity<Map<String, Object>> testWithSession(
+            @RequestParam String sessionId,
+            HttpServletRequest request) {
+        
+        log.info("세션 ID로 인증 테스트: {}", sessionId);
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "세션 ID 테스트");
+        response.put("sessionId", sessionId);
+        response.put("requestSessionId", request.getSession().getId());
+        
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/providers")
+    public ResponseEntity<Map<String, Object>> getAvailableProviders() {
+        log.info("사용 가능한 OAuth2 제공자 조회");
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("providers", Map.of(
+            "naver", "/oauth2/authorization/naver",
+            "google", "/oauth2/authorization/google"
+        ));
+        response.put("message", "사용 가능한 OAuth2 제공자 목록");
+        
+        return ResponseEntity.ok(response);
+    }
+    
+    @GetMapping("/me")
+    public ResponseEntity<Map<String, Object>> getCurrentUser(@AuthenticationPrincipal OAuth2User oAuth2User) {
+        if (oAuth2User == null) {
+            return ResponseEntity.status(401).body(Map.of("message", "인증되지 않은 사용자입니다."));
+        }
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("user", oAuth2User.getAttributes());
+        
+        return ResponseEntity.ok(response);
+    }
+    
+    @PostMapping("/logout")
+    public ResponseEntity<Map<String, String>> logout(HttpServletRequest request, HttpServletResponse response) {
+        log.info("로그아웃 요청");
+        
+        // Spring Security 컨텍스트 클리어
+        org.springframework.security.core.context.SecurityContextHolder.clearContext();
+        
+        // 세션 무효화
+        request.getSession().invalidate();
+        
+        // JSESSIONID 쿠키 삭제
+        Cookie sessionCookie = new Cookie("JSESSIONID", null);
+        sessionCookie.setPath("/");
+        sessionCookie.setMaxAge(0);
+        response.addCookie(sessionCookie);
+        
+        Map<String, String> responseData = new HashMap<>();
+        responseData.put("message", "로그아웃되었습니다.");
+        responseData.put("status", "success");
+        
+        log.info("로그아웃 완료: Security 컨텍스트 클리어, 세션 무효화 및 쿠키 삭제");
+        
+        return ResponseEntity.ok(responseData);
+    }
+} 

--- a/src/main/java/com/example/news/controller/AuthController.java
+++ b/src/main/java/com/example/news/controller/AuthController.java
@@ -80,7 +80,8 @@ public class AuthController {
         Map<String, Object> response = new HashMap<>();
         response.put("providers", Map.of(
             "naver", "/oauth2/authorization/naver",
-            "google", "/oauth2/authorization/google"
+            "google", "/oauth2/authorization/google",
+            "kakao", "/oauth2/authorization/kakao"
         ));
         response.put("message", "사용 가능한 OAuth2 제공자 목록");
         

--- a/src/main/java/com/example/news/controller/ElasticsearchController.java
+++ b/src/main/java/com/example/news/controller/ElasticsearchController.java
@@ -9,7 +9,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.time.LocalDateTime;
+
 import java.util.List;
 import java.util.Optional;
 
@@ -132,145 +132,7 @@ public class ElasticsearchController {
         return ResponseEntity.ok().build();
     }
 
-    @PostMapping("/test-data")
-    public ResponseEntity<String> createTestData() {
-        log.info("테스트 데이터 생성 요청");
-        
-        // 샘플 뉴스 데이터 생성
-        NewsDocument testNews1 = NewsDocument.builder()
-                .title("Breaking News: Technology Advances in AI")
-                .content("Artificial Intelligence has made significant progress in recent years. Researchers are developing new algorithms that can process natural language more effectively.")
-                .source("Tech News")
-                .url("https://example.com/tech-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Technology")
-                .author("John Doe")
-                .language("en")
-                .build();
 
-        NewsDocument testNews2 = NewsDocument.builder()
-                .title("Climate Change: Global Impact on Environment")
-                .content("Climate change continues to affect our planet. Scientists warn about rising temperatures and their effects on ecosystems worldwide.")
-                .source("Environmental News")
-                .url("https://example.com/env-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Environment")
-                .author("Jane Smith")
-                .language("en")
-                .build();
 
-        NewsDocument testNews3 = NewsDocument.builder()
-                .title("Economic Growth: Market Trends Analysis")
-                .content("The global economy shows signs of recovery. Market analysts predict positive trends for the upcoming quarter.")
-                .source("Business News")
-                .url("https://example.com/business-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Business")
-                .author("Mike Johnson")
-                .language("en")
-                .build();
 
-        elasticsearchService.saveAllNews(List.of(testNews1, testNews2, testNews3));
-        
-        return ResponseEntity.ok("테스트 데이터가 성공적으로 생성되었습니다.");
-    }
-
-    @PostMapping("/test-data-diverse")
-    public ResponseEntity<String> createDiverseTestData() {
-        log.info("다양한 테스트 데이터 생성 요청");
-        
-        List<NewsDocument> diverseNews = List.of(
-            NewsDocument.builder()
-                .title("Space Exploration: Mars Mission Success")
-                .content("NASA's latest Mars rover has successfully landed and begun transmitting data. Scientists are excited about the potential discoveries about the red planet's geology and atmosphere.")
-                .source("Space News")
-                .url("https://example.com/space-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Science")
-                .author("Dr. Sarah Wilson")
-                .language("en")
-                .build(),
-                
-            NewsDocument.builder()
-                .title("Healthcare Breakthrough: New Cancer Treatment")
-                .content("Medical researchers have developed a revolutionary immunotherapy treatment that shows promising results in early clinical trials. This breakthrough could change how we approach cancer treatment.")
-                .source("Medical News")
-                .url("https://example.com/medical-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Health")
-                .author("Dr. Michael Chen")
-                .language("en")
-                .build(),
-                
-            NewsDocument.builder()
-                .title("Sports: World Cup Final Results")
-                .content("In an exciting match that went to penalties, the underdog team emerged victorious. Fans around the world celebrated this unexpected outcome in the most watched sporting event.")
-                .source("Sports News")
-                .url("https://example.com/sports-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Sports")
-                .author("Alex Rodriguez")
-                .language("en")
-                .build(),
-                
-            NewsDocument.builder()
-                .title("Entertainment: New Blockbuster Movie Release")
-                .content("The highly anticipated sci-fi movie has broken box office records in its opening weekend. Critics praise the innovative special effects and compelling storyline.")
-                .source("Entertainment News")
-                .url("https://example.com/entertainment-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Entertainment")
-                .author("Lisa Thompson")
-                .language("en")
-                .build(),
-                
-            NewsDocument.builder()
-                .title("Education: Online Learning Revolution")
-                .content("Universities worldwide are adopting hybrid learning models. Students and educators are discovering new ways to engage in virtual classrooms.")
-                .source("Education News")
-                .url("https://example.com/education-news-1")
-                .publishedAt(LocalDateTime.now())
-                .category("Education")
-                .author("Prof. David Brown")
-                .language("en")
-                .build(),
-                
-            NewsDocument.builder()
-                .title("Technology: Quantum Computing Milestone")
-                .content("Scientists have achieved quantum supremacy in a new experiment. This breakthrough could revolutionize cryptography and computational power.")
-                .source("Tech News")
-                .url("https://example.com/tech-news-2")
-                .publishedAt(LocalDateTime.now())
-                .category("Technology")
-                .author("Dr. Emily Zhang")
-                .language("en")
-                .build(),
-                
-            NewsDocument.builder()
-                .title("Environment: Renewable Energy Adoption")
-                .content("Countries are rapidly transitioning to renewable energy sources. Solar and wind power installations have reached record levels globally.")
-                .source("Environmental News")
-                .url("https://example.com/env-news-2")
-                .publishedAt(LocalDateTime.now())
-                .category("Environment")
-                .author("Maria Garcia")
-                .language("en")
-                .build(),
-                
-            NewsDocument.builder()
-                .title("Business: Startup Success Story")
-                .content("A small startup has become a unicorn company in just three years. Their innovative approach to solving everyday problems has attracted major investors.")
-                .source("Business News")
-                .url("https://example.com/business-news-2")
-                .publishedAt(LocalDateTime.now())
-                .category("Business")
-                .author("Robert Kim")
-                .language("en")
-                .build()
-        );
-
-        elasticsearchService.saveAllNews(diverseNews);
-        
-        return ResponseEntity.ok("다양한 테스트 데이터가 성공적으로 생성되었습니다. 총 " + diverseNews.size() + "개의 뉴스가 추가되었습니다.");
-    }
 } 

--- a/src/main/java/com/example/news/dto/GoogleUserInfo.java
+++ b/src/main/java/com/example/news/dto/GoogleUserInfo.java
@@ -1,0 +1,61 @@
+package com.example.news.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class GoogleUserInfo implements OAuth2UserInfo {
+    
+    @JsonProperty("sub")
+    private String sub;
+    
+    @JsonProperty("name")
+    private String name;
+    
+    @JsonProperty("given_name")
+    private String givenName;
+    
+    @JsonProperty("family_name")
+    private String familyName;
+    
+    @JsonProperty("picture")
+    private String picture;
+    
+    @JsonProperty("email")
+    private String email;
+    
+    @JsonProperty("email_verified")
+    private Boolean emailVerified;
+    
+    @JsonProperty("locale")
+    private String locale;
+    
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+    
+    @Override
+    public String getProviderId() {
+        return sub;
+    }
+    
+    @Override
+    public String getName() {
+        return name;
+    }
+    
+    @Override
+    public String getEmail() {
+        return email;
+    }
+    
+    @Override
+    public String getProfileImage() {
+        return picture;
+    }
+} 

--- a/src/main/java/com/example/news/dto/KakaoUserInfo.java
+++ b/src/main/java/com/example/news/dto/KakaoUserInfo.java
@@ -1,0 +1,58 @@
+package com.example.news.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class KakaoUserInfo implements OAuth2UserInfo {
+    
+    @JsonProperty("id")
+    private Long id;
+    
+    @JsonProperty("connected_at")
+    private String connectedAt;
+    
+    @JsonProperty("properties")
+    private Map<String, Object> properties;
+    
+    @JsonProperty("kakao_account")
+    private Map<String, Object> kakaoAccount;
+    
+    @Override
+    public String getProvider() {
+        return "kakao";
+    }
+    
+    @Override
+    public String getProviderId() {
+        return String.valueOf(id);
+    }
+    
+    @Override
+    public String getName() {
+        if (properties != null && properties.containsKey("nickname")) {
+            return (String) properties.get("nickname");
+        }
+        return null;
+    }
+    
+    @Override
+    public String getEmail() {
+        if (kakaoAccount != null && kakaoAccount.containsKey("email")) {
+            return (String) kakaoAccount.get("email");
+        }
+        return null;
+    }
+    
+    @Override
+    public String getProfileImage() {
+        if (properties != null && properties.containsKey("profile_image")) {
+            return (String) properties.get("profile_image");
+        }
+        return null;
+    }
+} 

--- a/src/main/java/com/example/news/dto/NaverUserInfo.java
+++ b/src/main/java/com/example/news/dto/NaverUserInfo.java
@@ -1,0 +1,40 @@
+package com.example.news.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.Map;
+
+@Getter
+@Setter
+public class NaverUserInfo implements OAuth2UserInfo {
+    
+    @JsonProperty("response")
+    private Map<String, Object> response;
+    
+    @Override
+    public String getProvider() {
+        return "naver";
+    }
+    
+    @Override
+    public String getProviderId() {
+        return (String) response.get("id");
+    }
+    
+    @Override
+    public String getName() {
+        return (String) response.get("name");
+    }
+    
+    @Override
+    public String getEmail() {
+        return (String) response.get("email");
+    }
+    
+    @Override
+    public String getProfileImage() {
+        return (String) response.get("profile_image");
+    }
+} 

--- a/src/main/java/com/example/news/dto/OAuth2UserInfo.java
+++ b/src/main/java/com/example/news/dto/OAuth2UserInfo.java
@@ -1,0 +1,9 @@
+package com.example.news.dto;
+
+public interface OAuth2UserInfo {
+    String getProvider();
+    String getProviderId();
+    String getName();
+    String getEmail();
+    String getProfileImage();
+} 

--- a/src/main/java/com/example/news/repository/UserRepository.java
+++ b/src/main/java/com/example/news/repository/UserRepository.java
@@ -7,4 +7,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
   Optional<User> findByProviderId(String providerId);
+  Optional<User> findByProviderAndProviderId(String provider, String providerId);
 }

--- a/src/main/java/com/example/news/service/GoogleOAuth2Service.java
+++ b/src/main/java/com/example/news/service/GoogleOAuth2Service.java
@@ -1,0 +1,79 @@
+package com.example.news.service;
+
+import com.example.news.dto.GoogleUserInfo;
+import com.example.news.dto.OAuth2UserInfo;
+import com.example.news.entity.User;
+import com.example.news.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class GoogleOAuth2Service implements OAuth2ProviderService {
+    
+    private final UserRepository userRepository;
+    
+    @Override
+    public String getProviderName() {
+        return "google";
+    }
+    
+    @Override
+    public OAuth2UserInfo convertToUserInfo(Object oAuth2User) {
+        OAuth2User user = (OAuth2User) oAuth2User;
+        Map<String, Object> attributes = user.getAttributes();
+        
+        GoogleUserInfo googleUserInfo = new GoogleUserInfo();
+        googleUserInfo.setSub((String) attributes.get("sub"));
+        googleUserInfo.setName((String) attributes.get("name"));
+        googleUserInfo.setGivenName((String) attributes.get("given_name"));
+        googleUserInfo.setFamilyName((String) attributes.get("family_name"));
+        googleUserInfo.setPicture((String) attributes.get("picture"));
+        googleUserInfo.setEmail((String) attributes.get("email"));
+        googleUserInfo.setEmailVerified((Boolean) attributes.get("email_verified"));
+        googleUserInfo.setLocale((String) attributes.get("locale"));
+        
+        return googleUserInfo;
+    }
+    
+    @Override
+    @Transactional
+    public User processOAuth2Login(OAuth2UserInfo userInfo) {
+        log.info("구글 OAuth2 로그인 처리 시작: providerId={}", userInfo.getProviderId());
+        
+        User user = findOrCreateUser(userInfo);
+        log.info("구글 OAuth2 로그인 처리 완료: userId={}", user.getId());
+        
+        return user;
+    }
+    
+    private User findOrCreateUser(OAuth2UserInfo userInfo) {
+        return userRepository.findByProviderAndProviderId(
+                userInfo.getProvider(), 
+                userInfo.getProviderId()
+        ).orElseGet(() -> createNewUser(userInfo));
+    }
+    
+    private User createNewUser(OAuth2UserInfo userInfo) {
+        User newUser = User.builder()
+                .provider(userInfo.getProvider())
+                .providerId(userInfo.getProviderId())
+                .name(userInfo.getName())
+                .email(userInfo.getEmail())
+                .createdAt(LocalDateTime.now())
+                .build();
+        
+        User savedUser = userRepository.save(newUser);
+        log.info("새 구글 사용자 생성: userId={}, providerId={}", 
+                savedUser.getId(), userInfo.getProviderId());
+        
+        return savedUser;
+    }
+} 

--- a/src/main/java/com/example/news/service/KakaoOAuth2Service.java
+++ b/src/main/java/com/example/news/service/KakaoOAuth2Service.java
@@ -1,0 +1,75 @@
+package com.example.news.service;
+
+import com.example.news.dto.KakaoUserInfo;
+import com.example.news.dto.OAuth2UserInfo;
+import com.example.news.entity.User;
+import com.example.news.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class KakaoOAuth2Service implements OAuth2ProviderService {
+    
+    private final UserRepository userRepository;
+    
+    @Override
+    public String getProviderName() {
+        return "kakao";
+    }
+    
+    @Override
+    public OAuth2UserInfo convertToUserInfo(Object oAuth2User) {
+        OAuth2User user = (OAuth2User) oAuth2User;
+        Map<String, Object> attributes = user.getAttributes();
+        
+        KakaoUserInfo kakaoUserInfo = new KakaoUserInfo();
+        kakaoUserInfo.setId((Long) attributes.get("id"));
+        kakaoUserInfo.setConnectedAt((String) attributes.get("connected_at"));
+        kakaoUserInfo.setProperties((Map<String, Object>) attributes.get("properties"));
+        kakaoUserInfo.setKakaoAccount((Map<String, Object>) attributes.get("kakao_account"));
+        
+        return kakaoUserInfo;
+    }
+    
+    @Override
+    @Transactional
+    public User processOAuth2Login(OAuth2UserInfo userInfo) {
+        log.info("카카오 OAuth2 로그인 처리 시작: providerId={}", userInfo.getProviderId());
+        
+        User user = findOrCreateUser(userInfo);
+        log.info("카카오 OAuth2 로그인 처리 완료: userId={}", user.getId());
+        
+        return user;
+    }
+    
+    private User findOrCreateUser(OAuth2UserInfo userInfo) {
+        return userRepository.findByProviderAndProviderId(
+                userInfo.getProvider(), 
+                userInfo.getProviderId()
+        ).orElseGet(() -> createNewUser(userInfo));
+    }
+    
+    private User createNewUser(OAuth2UserInfo userInfo) {
+        User newUser = User.builder()
+                .provider(userInfo.getProvider())
+                .providerId(userInfo.getProviderId())
+                .name(userInfo.getName())
+                .email(userInfo.getEmail())
+                .createdAt(LocalDateTime.now())
+                .build();
+        
+        User savedUser = userRepository.save(newUser);
+        log.info("새 카카오 사용자 생성: userId={}, providerId={}", 
+                savedUser.getId(), userInfo.getProviderId());
+        
+        return savedUser;
+    }
+} 

--- a/src/main/java/com/example/news/service/NaverOAuth2Service.java
+++ b/src/main/java/com/example/news/service/NaverOAuth2Service.java
@@ -1,0 +1,74 @@
+package com.example.news.service;
+
+import com.example.news.dto.NaverUserInfo;
+import com.example.news.dto.OAuth2UserInfo;
+import com.example.news.entity.User;
+import com.example.news.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class NaverOAuth2Service implements OAuth2ProviderService {
+    
+    private final UserRepository userRepository;
+    
+    @Override
+    public String getProviderName() {
+        return "naver";
+    }
+    
+    @Override
+    public OAuth2UserInfo convertToUserInfo(Object oAuth2User) {
+        OAuth2User user = (OAuth2User) oAuth2User;
+        Map<String, Object> attributes = user.getAttributes();
+        
+        NaverUserInfo naverUserInfo = new NaverUserInfo();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> response = (Map<String, Object>) attributes.get("response");
+        naverUserInfo.setResponse(response);
+        
+        return naverUserInfo;
+    }
+    
+    @Override
+    @Transactional
+    public User processOAuth2Login(OAuth2UserInfo userInfo) {
+        log.info("네이버 OAuth2 로그인 처리 시작: providerId={}", userInfo.getProviderId());
+        
+        User user = findOrCreateUser(userInfo);
+        log.info("네이버 OAuth2 로그인 처리 완료: userId={}", user.getId());
+        
+        return user;
+    }
+    
+    private User findOrCreateUser(OAuth2UserInfo userInfo) {
+        return userRepository.findByProviderAndProviderId(
+                userInfo.getProvider(), 
+                userInfo.getProviderId()
+        ).orElseGet(() -> createNewUser(userInfo));
+    }
+    
+    private User createNewUser(OAuth2UserInfo userInfo) {
+        User newUser = User.builder()
+                .provider(userInfo.getProvider())
+                .providerId(userInfo.getProviderId())
+                .name(userInfo.getName())
+                .email(userInfo.getEmail())
+                .createdAt(LocalDateTime.now())
+                .build();
+        
+        User savedUser = userRepository.save(newUser);
+        log.info("새 네이버 사용자 생성: userId={}, providerId={}", 
+                savedUser.getId(), userInfo.getProviderId());
+        
+        return savedUser;
+    }
+} 

--- a/src/main/java/com/example/news/service/OAuth2ProviderService.java
+++ b/src/main/java/com/example/news/service/OAuth2ProviderService.java
@@ -1,0 +1,10 @@
+package com.example.news.service;
+
+import com.example.news.dto.OAuth2UserInfo;
+import com.example.news.entity.User;
+
+public interface OAuth2ProviderService {
+    String getProviderName();
+    OAuth2UserInfo convertToUserInfo(Object oAuth2User);
+    User processOAuth2Login(OAuth2UserInfo userInfo);
+} 

--- a/src/main/java/com/example/news/service/impl/AIServiceImpl.java
+++ b/src/main/java/com/example/news/service/impl/AIServiceImpl.java
@@ -68,23 +68,31 @@ public class AIServiceImpl implements AIService {
 
       // 더 빠른 요약 모델들 (순서대로 시도)
       String[] modelUrls = {
-        "https://api-inference.huggingface.co/models/facebook/bart-large-cnn"// 원본 (백업)
+        "https://api-inference.huggingface.co/models/sshleifer/distilbart-cnn-12-6", // 더 빠른 모델
+        "https://api-inference.huggingface.co/models/facebook/bart-large-cnn",      // 원본 (백업)
+        "https://api-inference.huggingface.co/models/facebook/bart-base"            // 기본 모델 (가장 빠름)
       };
 
       ResponseEntity<String> response = null;
       Exception lastException = null;
 
       for (String modelUrl : modelUrls) {
+        long startTime = System.currentTimeMillis();
         try {
           log.info("Trying model: {}", modelUrl);
           response = restTemplate.postForEntity(modelUrl, entity, String.class);
+          long endTime = System.currentTimeMillis();
           
           if (response.getStatusCode().is2xxSuccessful()) {
-            log.info("Success with model: {}", modelUrl);
+            log.info("Success with model: {} (took {}ms)", modelUrl, endTime - startTime);
             break;
+          } else {
+            log.warn("Model {} returned status: {}", modelUrl, response.getStatusCode());
           }
         } catch (Exception e) {
-          log.warn("Failed with model {}: {}", modelUrl, e.getMessage());
+          long endTime = System.currentTimeMillis();
+          log.warn("Failed with model {}: {} (after {}ms)", modelUrl, e.getMessage(), 
+                   endTime - startTime);
           lastException = e;
           continue;
         }


### PR DESCRIPTION
### **1️⃣ Elastic Search 연동 작업 (3차)**
- Elastic Search 연동 마무리 작업

### **📌 (7/1)**

- 더 이상 필요 없는 테스트 데이터 생성 로직 제거
- 실제 API 데이터만 사용하도록 정리
- RestTemplate 타임아웃 설정 개선 (5분)
- 더 빠른 AI 요약 모델 추가
- 에러 처리 및 로깅 개선


✅ 테스트 완료
- 모든 API가 200 OK 응답 반환
- 카테고리 / 키워드 검색 기능 정상 작동
- Elasticsearch 캐싱으로 뉴스 정보 저장

( 요약/번역 기능 API - 카테고리 검색 기능 API - 자연어 검색 기능 API)

![주요 기능 API 테스트](https://github.com/user-attachments/assets/5ab30fde-82c0-4468-a198-c72cf8613fd2)


( Elasticsearch 캐싱 개발자용 API 테스트 )
![개발자용 API 테스트(E S)](https://github.com/user-attachments/assets/6d5eae2f-e77b-47e1-a791-7fb5e6abd3f9)



⏭️ [ NEXT ]
- 소셜로그인 구현 (구글/네이버)


-----------------------------------------------------------------


### **2️⃣ 소셜 로그인 구현**

### **📌 (7/2)**

- 소셜로그인 구현 (카카오/네이버) / OAuth2 로그인 세션 기반 인증
- 로그인 시 sessionId 를 링크에 포함하여 반환하도록 처리 (프론트에서 용이한 처리)
- NAVER / Google 로그인 기능 구현
- 구현 기능  API 테스트

**🛠️ 수정**
- Jackson이 LocalDateTime을 JSON으로 직렬화할 때 발생하는 문제
- Jackson 설정에 LocalDateTime 직렬화 설정 추가 / SummaryResponse에서 LocalDateTime을 String으로 변환

**✅ 테스트 완료**

( 구글 로그인 후 사용자 정보 조회 - 구글 로그아웃 - 구글 로그아웃 후 사용정보 조회 )
/ 테스트 이미지 삭제

( 네이버 로그인 후 사용자 정보 조회 - 네이버 로그아웃 - 네이버 로그아웃 후 사용정보 조회 )
/테스트 이미지 삭제


**⏭️ [ NEXT ]**
- 소셜로그인 구현 (카카오)



-----------------------------------------------------------------



### **📌 (7/3)**

- OAuth2 로그인 세션 기반 인증
- KAKAO 로그인 기능 구현
- 구현 기능 API 테스트


**🛠️ 수정**
- 확장 가능한 OAuth2 서비스 구조로 리팩토링

**🚫 문제점**
- 단일 서비스 인터페이스 와 단일 구현체로 모든 OAuth2 제공자 로직이 하나의 클래스에 혼재하는 단순구현
- 새로운 OAuth2 제공자 추가 시 기존 코드 수정 필요
- 각 제공자별 특수한 로직 처리가 어려움
- 단일 책임 원칙 위반

**✅ 개선 방향**
- 각 OAuth2 제공자별 서비스 인터페이스 설계로 확장 가능에 용이하도록 수정
- 네이버/구글/카카오 제공자별 독립적인 구현체로 구분
- 의존성 역전 원칙 : 구체적인 구현체가 아닌 인터페이스에 의존하도록 함
- 개방-폐쇄 원칙 : 새로운 제공자 추가 시 기존 코드 수정 없이 확장 가능하도록 함
- 단일 책임 원칙 : 각 서비스는 하나의 OAuth2 제공자만 담당하도록 하고 네이버 로직 변경이 구글 로직에 영향 없도록 함

**💡기대효과**
- 확장성과 유지보수성 향상

**✅ 테스트 완료**
- 네이버/구글/카카오 로그인 구현 기능  API 테스트